### PR TITLE
Fixed minor error in sample command in main slides in mv command.

### DIFF
--- a/lecture_notes/source/using_linux_tools/handout.rst
+++ b/lecture_notes/source/using_linux_tools/handout.rst
@@ -1986,13 +1986,15 @@ hyphens.
     echo $f|tr -s " " "-"|cut -d - -f 2-
   done
 
-Now we just replace the echo command with a ``mv``  command. 
+Now we just replace the echo command with a ``mv``  command. Note that ``Si`` 
+has to be within quotes as ``mv`` takes it to be 2 different inputs as it has 
+space in it. 
 
 ::
 
   for i in *.mp3
   do 
-    mv $i `echo $f|tr -s " " "-"|cut -d - -f 2-`
+    mv "$i" `echo $f|tr -s " " "-"|cut -d - -f 2-`
   done
 
 ``while``


### PR DESCRIPTION
A sample on application of mv command for renaming files had a minor error. Since the files to be renamed were being taken in a loop and they had spaces in their names, the mv command took the 2 parts of the string '$i' as its 2 inputs.Changed $i to "$i" and it works just fine.